### PR TITLE
Has Games Filter, Minor build speed improvement

### DIFF
--- a/src/modules/layouts/SiteContext.js
+++ b/src/modules/layouts/SiteContext.js
@@ -42,6 +42,7 @@ const SiteProvider = ({ children, value }) => {
   `)
 
   const AllFilters = {}
+  const ExistsFilters = [{fragment: "Games", regex: /\[([^\[]+)\](\(.*\))/gm}]
   const filterFragments = ["Skills", "Location"] //<- Update this to match React Fragment keynames for filtering!
 
   //Transform that data into something consumable (People, Companies)
@@ -68,6 +69,38 @@ const SiteProvider = ({ children, value }) => {
         //NOTE(Rejon): Because filters are automagically generated we do the heavy lifting to sanitize text.
         //             We do this to get our filters into something consistent for comparisons, rendering, and querying via input.
         AllFilters[fragment].push(_filter)
+      }
+    })
+
+
+    //Map for "Has" filters.
+    //Checks if exists filters with their regex match 
+    //has a quantifiable amount to suggest an entry "Having [X]" 
+    ExistsFilters.map(({fragment, regex}) => {
+      if (node.rawBody.includes(`<${fragment}>`)) {
+        const matches = node.rawBody.match(regex); //Regex match based on fragment
+        
+        //If there's more than 0 matches, 
+        //this entry HAS fragment data.
+        if (matches.length > 0) 
+        {
+          if (!AllFilters['Has']) {
+            AllFilters['Has'] = [];
+          }
+
+          if (!filterData['Has']) {
+            filterData['Has'] = [];
+          }
+
+          const hasFilterData = {
+            label: fragment,
+            key: fragment,
+            set: 'Has'
+          };
+
+          filterData['Has'].push(hasFilterData)
+          AllFilters['Has'].push(hasFilterData)
+        }
       }
     })
 

--- a/src/modules/layouts/footer.js
+++ b/src/modules/layouts/footer.js
@@ -5,43 +5,28 @@
 // but if you know your way around, go crazy :)
 //** @jsx jsx */
 import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
-import { MDXProvider } from "@mdx-js/react"
-import { MDXRenderer } from "gatsby-plugin-mdx"
+import Link from "@modules/utility/Link"
 import { Box, jsx } from "theme-ui"
-
-import shortcodes from "@ui/shortcodes"
-
 const Footer = () => {
-  const { allMdx: edges } = useStaticQuery(graphql`
-    query GetFooter {
-      allMdx(filter: { fileAbsolutePath: { regex: "/footer.mdx/" } }) {
-        edges {
-          node {
-            body
-          }
-        }
-      }
-    }
-  `)
-
-  if (edges.edges[0] === undefined) {
-    return <></>
-  }
-
   return (
     <Box
       sx={{
-        "& > *": { color: "primary" },
+        color: "primary",
         fontFamily: "heading",
         borderTop: "1px dotted",
         borderColor: "border",
         mt: "3rem",
+        pt: 3
       }}
     >
-      <MDXProvider components={shortcodes}>
-        <MDXRenderer>{edges.edges[0].node.body}</MDXRenderer>
-      </MDXProvider>
+      A project by 
+      <Link to="https://quantumbox.itch.io/" sx={{ml: 1}}>Arthur Ward, Jr.</Link>, 
+       <Link to="https://cattsmall.com" sx={{ml: 1}}>Catt Small</Link>,
+      & <Link to="https://chrisalgoo.com"> Chris Agloo</Link>.
+       Want to add to the list? <Link to="https://github.com/QuantumBox/blackgamedevs#want-to-add-someone-to-the-list">Go here.</Link>
+      <br/>
+      <br/>
+      Maxed out with love by <Link to="https://rejontaylor.com">Réjon Taylor-Foster (@Maximum_Crash)</Link>
     </Box>
   )
 }

--- a/src/modules/search/filters.js
+++ b/src/modules/search/filters.js
@@ -211,6 +211,7 @@ const Filters = () => {
         ref={filterListEl}
         sx={{ pl: "1rem", pr: "1rem", mt: ".24rem", maxHeight: ['73vh', 'unset', 'unset'], overflow: filtersOpen ? 'auto !important' : 'hidden' }}
       >
+        
         {Object.keys(AllFilters).map((set, index) => (
           <FilterSet
             filtersOfSet={AllFilters[set]}
@@ -225,6 +226,8 @@ const Filters = () => {
             {set}
           </FilterSet>
         ))}
+
+        
       </SmoothCollapse>
     </Box>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -10,7 +10,6 @@ import {filterObjectData} from '@utils';
 
 const Index = ({ data, location }) => {
   const { filters, results } = useSite()
-
   const peopleResults = Object.values(
     filterObjectData(
       results,
@@ -19,7 +18,7 @@ const Index = ({ data, location }) => {
         (filters.length > 0
           ? filters.some(f => {
               if (!entry[f.set] || !entry[f.set].length) return false
-
+              
               return entry[f.set].find(n => n.key === f.key)
             })
           : true)

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,3 +55,5 @@ export const flattenFilter = filtersOfSet =>
       return acc
     }
   }, [])
+
+  export const markdownLinkRegex = /\[([^\[]+)\](\(.*\))/gm;


### PR DESCRIPTION
Issue: #107 

This PR adds the "Has" filter feature for supporting if an entry contains..."something". 

For example, the Issue above requested having a filter for entries with games. The execution of this is to have an array of objects with fragments and a regex pattern based on the way the markdown data is organized. 

```
  const ExistsFilters = [{fragment: "Games", regex: /\[([^\[]+)\](\(.*\))/gm}]
```

We then map through the ExistsFilter array in a similar fashion to the filterFragments array, except this time we skip sanitizing the filter (santizing is only helpful for a specific context). 

With this execution we should be able to add more "Has" filters depending on the needs of our users. 

![Screen Shot 2020-11-11 at 12 24 46 PM](https://user-images.githubusercontent.com/9157341/98845415-abcd2f80-241b-11eb-8402-a76e8b8a34fb.png)
![Screen Shot 2020-11-11 at 12 24 35 PM](https://user-images.githubusercontent.com/9157341/98845418-abcd2f80-241b-11eb-8164-86855fc6eb1b.png)
 